### PR TITLE
Issue #8 adjustment for new extra component handling

### DIFF
--- a/src/main/java/ca/corbett/imageviewer/extensions/quickaccess/QuickAccessPanel.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/quickaccess/QuickAccessPanel.java
@@ -40,6 +40,7 @@ public final class QuickAccessPanel extends JPanel {
      */
     public QuickAccessPanel() {
         this.setBorder(null);
+        this.setName("Quick Access"); // in case our component gets added to a JTabbedPane.
 
         wrapperPanel = new JPanel(new GridBagLayout());
         JScrollPane scrollPane = new JScrollPane(wrapperPanel);


### PR DESCRIPTION
Issue #8 is largely obsolete due to recent changes in the parent application. The only change required here for this issue is to set a name for our returned extra component, so that the parent application can render it properly in a JTabbedPane. Our logic around making the panel visible/invisible depending on browse mode is unchanged.