### PR TITLE
Dev branch for 3.1.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ left, and hit the "Uninstall" button in the top right. The application will prom
 ### Option 2: manual download and install:
 
 You can manually download the extension jar:
-[ext-iv-quick-access-3.1.0.jar](http://www.corbett.ca/apps/ImageViewer/extensions/3.0/ext-iv-quick-access-3.1.0.jar)
+[ext-iv-quick-access-3.2.0.jar](http://www.corbett.ca/apps/ImageViewer/extensions/3.0/ext-iv-quick-access-3.2.0.jar)
 
 Save it to your ~/.ImageViewer/extensions directory and restart the application.
 
@@ -34,10 +34,12 @@ You can clone this repo and build the extension jar with Maven (Java 17 or highe
 ```shell
 git clone https://github.com/scorbo2/ext-iv-quick-access.git
 cd ext-iv-quick-access
-maven package
+
+# Note: you must have run `mvn install` in the main ImageViewer repo first, as that is a dependency for this code.
+mvn package
 
 # Copy the result to extensions directory:
-cp target/ext-iv-quick-access-3.1.0.jar ~/.ImageViewer/extensions/
+cp target/ext-iv-quick-access-3.2.0.jar ~/.ImageViewer/extensions/
 ```
 
 ## Okay, it's installed, now how do I use it?

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ left, and hit the "Uninstall" button in the top right. The application will prom
 ### Option 2: manual download and install:
 
 You can manually download the extension jar:
-[ext-iv-quick-access-3.2.0.jar](http://www.corbett.ca/apps/ImageViewer/extensions/3.0/ext-iv-quick-access-3.2.0.jar)
+[ext-iv-quick-access-3.2.0.jar](http://www.corbett.ca/apps/ImageViewer/extensions/3.2/ext-iv-quick-access-3.2.0.jar)
 
 Save it to your ~/.ImageViewer/extensions directory and restart the application.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ left, and hit the "Uninstall" button in the top right. The application will prom
 ### Option 2: manual download and install:
 
 You can manually download the extension jar:
-[ext-iv-quick-access-3.0.0.jar](http://www.corbett.ca/apps/ImageViewer/extensions/3.0/ext-iv-quick-access-3.0.0.jar)
+[ext-iv-quick-access-3.1.0.jar](http://www.corbett.ca/apps/ImageViewer/extensions/3.0/ext-iv-quick-access-3.1.0.jar)
 
 Save it to your ~/.ImageViewer/extensions directory and restart the application.
 
@@ -37,7 +37,7 @@ cd ext-iv-quick-access
 maven package
 
 # Copy the result to extensions directory:
-cp target/ext-iv-quick-access-3.0.0.jar ~/.ImageViewer/extensions/
+cp target/ext-iv-quick-access-3.1.0.jar ~/.ImageViewer/extensions/
 ```
 
 ## Okay, it's installed, now how do I use it?
@@ -47,7 +47,7 @@ Destinations configuration dialog:
 
 ![Screenshot1](screenshot1.png "Screenshot 1")
 
-You can add directories here, recursively if needed, and even rename them for labelling purposes.
+You can add directories here, recursively if needed, and even rename them for labeling purposes.
 The Quick Access panel will show up by default on the left side of the main image panel (you can configure
 the location of the Quick Access panel in application settings):
 
@@ -62,6 +62,11 @@ You can easily get it back by revisiting the Quick Access Destinations configura
 Note that the hierarchy of destinations presented on the Quick Access panel doesn't have to match the
 hierarchy of directories on the file system! Using the Quick Access Destinations configuration dialog,
 you can create whatever hierarchy makes sense, regardless of how the file system is laid out.
+
+## More information
+
+- Project GitHub page: [ext-iv-quick-access](https://github.com/scorbo2/ext-iv-quick-access)
+- Project issues page: [ext-iv-quick-access issues](https://github.com/scorbo2/ext-iv-quick-access/issues)
 
 ## Requirements
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ca.corbett</groupId>
     <artifactId>ext-iv-quick-access</artifactId>
-    <version>3.0.0</version>
+    <version>3.1.0</version>
 
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>ca.corbett</groupId>
             <artifactId>imageviewer</artifactId>
-            <version>3.0</version>
+            <version>3.1</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ca.corbett</groupId>
     <artifactId>ext-iv-quick-access</artifactId>
-    <version>3.1.0</version>
+    <version>3.2.0</version>
 
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>ca.corbett</groupId>
             <artifactId>imageviewer</artifactId>
-            <version>3.1</version>
+            <version>3.2</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/ca/corbett/imageviewer/extensions/quickaccess/QuickAccessExtension.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/quickaccess/QuickAccessExtension.java
@@ -238,7 +238,6 @@ public class QuickAccessExtension extends ImageViewerExtension implements UIRelo
         for (QuickAccessPanel quickAccessPanel : quickAccessPanels) {
             quickAccessPanel.setActionPanelColors();
             quickAccessPanel.refreshPreferredWidth(); // user may have changed the preferred quick panel width
-            quickAccessPanel.applyLafWorkaround(); // user may have changed color scheme
         }
     }
 

--- a/src/main/java/ca/corbett/imageviewer/extensions/quickaccess/QuickAccessExtension.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/quickaccess/QuickAccessExtension.java
@@ -3,6 +3,7 @@ package ca.corbett.imageviewer.extensions.quickaccess;
 import ca.corbett.extensions.AppExtensionInfo;
 import ca.corbett.extras.properties.AbstractProperty;
 import ca.corbett.extras.properties.ComboProperty;
+import ca.corbett.extras.properties.IntegerProperty;
 import ca.corbett.imageviewer.AppConfig;
 import ca.corbett.imageviewer.QuickMoveManager;
 import ca.corbett.imageviewer.extensions.ImageViewerExtension;
@@ -35,6 +36,7 @@ public class QuickAccessExtension extends ImageViewerExtension implements UIRelo
 
     private static final String extInfoLocation = "/ca/corbett/imageviewer/extensions/quickaccess/extInfo.json";
     private static final String positionPropName = "Quick Move.Quick Access Extension.position";
+    public static final String panelMinWidthPropName = "Quick Move.Quick Access Extension.quickTagPanelMinWidth";
 
     private static final String WRONG_MODE_WARNING = "Not available\nin ImageSet mode.";
 
@@ -118,7 +120,8 @@ public class QuickAccessExtension extends ImageViewerExtension implements UIRelo
 
     @Override
     protected List<AbstractProperty> createConfigProperties() {
-        return List.of(
+        List<AbstractProperty> props = new ArrayList<>();
+        props.add(
             // We can't use EnumProperty because we don't support all enum options...
             // we only support Left and Right. So, use String-based combo instead.
             new ComboProperty<>(positionPropName,
@@ -127,6 +130,11 @@ public class QuickAccessExtension extends ImageViewerExtension implements UIRelo
                                 0,
                                 false)
         );
+
+        props.add(new IntegerProperty(panelMinWidthPropName,
+                                      "Panel minimum width:", 200, 120, 300, 10));
+
+        return props;
     }
 
     /**
@@ -229,6 +237,7 @@ public class QuickAccessExtension extends ImageViewerExtension implements UIRelo
     public void reloadUI() {
         for (QuickAccessPanel quickAccessPanel : quickAccessPanels) {
             quickAccessPanel.setActionPanelColors();
+            quickAccessPanel.refreshPreferredWidth(); // user may have changed the preferred quick panel width
             quickAccessPanel.applyLafWorkaround(); // user may have changed color scheme
         }
     }

--- a/src/main/java/ca/corbett/imageviewer/extensions/quickaccess/QuickAccessExtension.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/quickaccess/QuickAccessExtension.java
@@ -36,7 +36,7 @@ public class QuickAccessExtension extends ImageViewerExtension implements UIRelo
 
     private static final String extInfoLocation = "/ca/corbett/imageviewer/extensions/quickaccess/extInfo.json";
     private static final String positionPropName = "Quick Move.Quick Access Extension.position";
-    public static final String panelMinWidthPropName = "Quick Move.Quick Access Extension.quickTagPanelMinWidth";
+    static final String panelMinWidthPropName = "Quick Move.Quick Access Extension.quickTagPanelMinWidth";
 
     private static final String WRONG_MODE_WARNING = "Not available\nin ImageSet mode.";
 

--- a/src/main/java/ca/corbett/imageviewer/extensions/quickaccess/QuickAccessPanel.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/quickaccess/QuickAccessPanel.java
@@ -1,7 +1,6 @@
 package ca.corbett.imageviewer.extensions.quickaccess;
 
 import ca.corbett.extras.EnhancedAction;
-import ca.corbett.extras.LookAndFeelManager;
 import ca.corbett.extras.ScrollUtil;
 import ca.corbett.extras.actionpanel.ActionComponentType;
 import ca.corbett.extras.actionpanel.ActionPanel;
@@ -19,9 +18,6 @@ import javax.swing.JLayer;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
-import javax.swing.UIManager;
-import javax.swing.event.ChangeListener;
-import javax.swing.plaf.ColorUIResource;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Dimension;
@@ -39,7 +35,6 @@ import java.io.File;
  */
 public final class QuickAccessPanel extends JPanel {
 
-    private final ChangeListener lafListener;
     private final BlurLayerUI blurLayerUI;
     private final ActionPanel actionPanel;
     private final JScrollPane scrollPane;
@@ -59,13 +54,6 @@ public final class QuickAccessPanel extends JPanel {
         scrollPane = ScrollUtil.buildScrollPane(new JLayer<>(actionPanel, blurLayerUI));
         refreshPreferredWidth();
         setActionPanelColors();
-
-        // Set up a Look and Feel change listener so we can apply our workaround:
-        lafListener = e -> applyLafWorkaround();
-        LookAndFeelManager.addChangeListener(lafListener);
-
-        // And force the workaround here for immediate effect:
-        applyLafWorkaround();
 
         setLayout(new BorderLayout());
         add(scrollPane, BorderLayout.CENTER);
@@ -104,7 +92,6 @@ public final class QuickAccessPanel extends JPanel {
      * Invoke this when the panel is no longer needed.
      */
     public void dispose() {
-        LookAndFeelManager.removeChangeListener(lafListener);
         actionPanel.dispose();
     }
 
@@ -191,48 +178,6 @@ public final class QuickAccessPanel extends JPanel {
         else {
             actionPanel.getColorOptions().useSystemDefaults();
         }
-    }
-
-    /**
-     * Works around an unfortunate bug in swing-extras regarding button colors in certain Look and Feels.
-     * The bug is that button borders are set to a very unpleasant default color for certain LaFs.
-     * This bug was not fixed before swing-extras 2.8 was released :(
-     */
-    public void applyLafWorkaround() {
-        // If a custom ActionPanel theme is in effect, tweak it:
-        Color borderColor;
-        ColorTheme appliedTheme = AppConfig.getInstance().getActionPanelTheme();
-        if (appliedTheme != null) {
-            borderColor = switch (appliedTheme) {
-                case DEFAULT, MATRIX, DARK, ICE -> Color.DARK_GRAY;
-                case LIGHT, GOT_THE_BLUES, SHADES_OF_GRAY -> Color.GRAY;
-                case HOT_DOG_STAND -> Color.YELLOW; // because hot dog stands are ugly
-            };
-        }
-
-        // If we're letting the Look and Feel decide our colors, then we'll
-        // decide based on whether the current LaF is dark or light.
-        // This isn't perfect, but it's better than the default:
-        else {
-            borderColor = LookAndFeelManager.isDark() ? Color.DARK_GRAY : Color.GRAY;
-        }
-
-        // Now overwrite the UIManager property in question:
-        // (This will have effects beyond our own action panel, but it is what it is
-        //  until this bug is properly addressed in swing-extras)
-        UIManager.put("Button.default.startBorderColor", new ColorUIResource(borderColor));
-
-        // Rebuild the action panel's UI without reloading contents from disk:
-        actionPanel.setAutoRebuildEnabled(false);
-        actionPanel.setAutoRebuildEnabled(true); // forces an immediate rebuild
-
-        // This is what I want to do instead of the above,
-        // but it won't work because of the way ActionPanel builds its buttons:
-        //SwingUtilities.updateComponentTreeUI(actionPanel);
-
-        invalidate();
-        revalidate();
-        repaint();
     }
 
     /**

--- a/src/main/java/ca/corbett/imageviewer/extensions/quickaccess/QuickAccessPanel.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/quickaccess/QuickAccessPanel.java
@@ -74,7 +74,7 @@ public final class QuickAccessPanel extends JPanel {
     }
 
     /**
-     * Looks up the currently-configured preferred width for quick tag panels
+     * Looks up the currently-configured minimum width for the Quick Access panel
      * from application settings and updates the instance variable.
      */
     public void refreshPreferredWidth() {

--- a/src/main/java/ca/corbett/imageviewer/extensions/quickaccess/QuickAccessPanel.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/quickaccess/QuickAccessPanel.java
@@ -8,6 +8,8 @@ import ca.corbett.extras.actionpanel.ActionPanel;
 import ca.corbett.extras.actionpanel.ColorOptions;
 import ca.corbett.extras.actionpanel.ColorTheme;
 import ca.corbett.extras.image.animation.BlurLayerUI;
+import ca.corbett.extras.properties.AbstractProperty;
+import ca.corbett.extras.properties.IntegerProperty;
 import ca.corbett.imageviewer.AppConfig;
 import ca.corbett.imageviewer.ImageOperationHandler;
 import ca.corbett.imageviewer.QuickMoveManager;
@@ -22,6 +24,7 @@ import javax.swing.event.ChangeListener;
 import javax.swing.plaf.ColorUIResource;
 import java.awt.BorderLayout;
 import java.awt.Color;
+import java.awt.Dimension;
 import java.awt.event.ActionEvent;
 import java.io.File;
 
@@ -42,6 +45,8 @@ public final class QuickAccessPanel extends JPanel {
     private final JScrollPane scrollPane;
     private final QuickAccessExtension extension;
 
+    private int panelMinWidth = 200; // customized via AppConfig
+
     /**
      * Creates a new, empty QuickAccessPanel.
      */
@@ -52,6 +57,7 @@ public final class QuickAccessPanel extends JPanel {
         blurLayerUI = new BlurLayerUI();
         actionPanel = buildActionPanel();
         scrollPane = ScrollUtil.buildScrollPane(new JLayer<>(actionPanel, blurLayerUI));
+        refreshPreferredWidth();
         setActionPanelColors();
 
         // Set up a Look and Feel change listener so we can apply our workaround:
@@ -77,6 +83,21 @@ public final class QuickAccessPanel extends JPanel {
      */
     public boolean isBlurred() {
         return blurLayerUI.isBlurred();
+    }
+
+    /**
+     * Looks up the currently-configured preferred width for quick tag panels
+     * from application settings and updates the instance variable.
+     */
+    public void refreshPreferredWidth() {
+        AbstractProperty prop = AppConfig.getInstance().getPropertiesManager()
+                                         .getProperty(QuickAccessExtension.panelMinWidthPropName);
+        if (prop instanceof IntegerProperty intProp) {
+            panelMinWidth = intProp.getValue();
+        }
+        else {
+            panelMinWidth = 200; // fallback to default if something goes wrong
+        }
     }
 
     /**
@@ -255,8 +276,22 @@ public final class QuickAccessPanel extends JPanel {
      * Invoked internally to build an ActionPanel and configure it for our use.
      */
     private ActionPanel buildActionPanel() {
+        // This is very weird, but calling setPreferredSize() on the ActionPanel itself
+        // prevents the scrollbar from ever showing up, even when the parent container is too
+        // small to show all contents. The only way I've found to make this work is
+        // to override ActionPanel itself and return the preferred size from there.
+        // All of this, by the way, is just so we can set our preferred width. Sigh.
+        ActionPanel panel = new ActionPanel() {
+            @Override
+            public Dimension getPreferredSize() {
+                Dimension superPref = super.getPreferredSize();
+                // Return the larger of the two (panel's width may be larger if contents are large):
+                return new Dimension(Math.max(panelMinWidth, superPref.width), superPref.height);
+            }
+        };
+
+        // Now we can customize ActionPanel to get it to look the way we want it to.
         final int iconSize = 18;
-        ActionPanel panel = new ActionPanel();
         panel.setHeaderIconSize(iconSize);
         panel.getToolBarOptions().setIconSize(iconSize);
         panel.setActionComponentType(ActionComponentType.BUTTONS);

--- a/src/main/java/ca/corbett/imageviewer/extensions/quickaccess/QuickAccessPanel.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/quickaccess/QuickAccessPanel.java
@@ -23,6 +23,7 @@ import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.event.ActionEvent;
 import java.io.File;
+import java.util.logging.Logger;
 
 /**
  * Provides a way to take one or more QuickMoveManager.TreeNode instances and turn them
@@ -34,6 +35,8 @@ import java.io.File;
  * @since ImageViewer 1.1
  */
 public final class QuickAccessPanel extends JPanel {
+
+    private static final Logger log = Logger.getLogger(QuickAccessPanel.class.getName());
 
     private final BlurLayerUI blurLayerUI;
     private final ActionPanel actionPanel;
@@ -84,8 +87,15 @@ public final class QuickAccessPanel extends JPanel {
             panelMinWidth = intProp.getValue();
         }
         else {
+            log.warning("Couldn't find integer property for quick access panel minimum width. " +
+                            "Using default value of " + panelMinWidth);
             panelMinWidth = 200; // fallback to default if something goes wrong
         }
+        invalidate();
+        revalidate();
+        repaint();
+        scrollPane.revalidate();
+        scrollPane.repaint();
     }
 
     /**

--- a/src/main/resources/ca/corbett/imageviewer/extensions/quickaccess/extInfo.json
+++ b/src/main/resources/ca/corbett/imageviewer/extensions/quickaccess/extInfo.json
@@ -1,9 +1,9 @@
 {
   "name": "Quick Access",
   "author": "steve@corbett.ca",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "targetAppName": "ImageViewer",
-  "targetAppVersion": "3.1",
+  "targetAppVersion": "3.2",
   "shortDescription": "Provides a panel of quick move options.",
   "longDescription": "Accessed through the Quick Move setup dialog, this extension allows you to select a particular quick move node to be displayed as buttons to the left or right of the main image panel, for very easy access."
 }

--- a/src/main/resources/ca/corbett/imageviewer/extensions/quickaccess/extInfo.json
+++ b/src/main/resources/ca/corbett/imageviewer/extensions/quickaccess/extInfo.json
@@ -1,9 +1,9 @@
 {
   "name": "Quick Access",
   "author": "steve@corbett.ca",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "targetAppName": "ImageViewer",
-  "targetAppVersion": "3.0",
+  "targetAppVersion": "3.1",
   "shortDescription": "Provides a panel of quick move options.",
   "longDescription": "Accessed through the Quick Move setup dialog, this extension allows you to select a particular quick move node to be displayed as buttons to the left or right of the main image panel, for very easy access."
 }


### PR DESCRIPTION
All PRs for the `3.2.0` release should target this branch.

Closes #14 Remove old LaF workaround
Closes #15 Make panel minimum width configurable

Upgraded to latest version of `3.2` of the parent application, and change this extension version to `3.2.0` to keep them in sync. (Really, the extension mechanism only matches major versions, so `3.x` of either would be compatible with `3.x` of the other, but matching up the version numbers like this keeps everything as unsurprising as possible).