### PR TITLE
Issue #15 - configurable panel width

### DIFF
--- a/src/main/java/ca/corbett/imageviewer/extensions/quickaccess/QuickAccessExtension.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/quickaccess/QuickAccessExtension.java
@@ -36,7 +36,7 @@ public class QuickAccessExtension extends ImageViewerExtension implements UIRelo
 
     private static final String extInfoLocation = "/ca/corbett/imageviewer/extensions/quickaccess/extInfo.json";
     private static final String positionPropName = "Quick Move.Quick Access Extension.position";
-    public static final String panelWidthPropName = "Quick Move.Quick Access Extension.quickTagPanelWidth";
+    public static final String panelMinWidthPropName = "Quick Move.Quick Access Extension.quickTagPanelMinWidth";
 
     private static final String WRONG_MODE_WARNING = "Not available\nin ImageSet mode.";
 
@@ -131,7 +131,8 @@ public class QuickAccessExtension extends ImageViewerExtension implements UIRelo
                                 false)
         );
 
-        props.add(new IntegerProperty(panelWidthPropName, "Panel width:", 200, 120, 300, 10));
+        props.add(new IntegerProperty(panelMinWidthPropName,
+                                      "Panel minimum width:", 200, 120, 300, 10));
 
         return props;
     }

--- a/src/main/java/ca/corbett/imageviewer/extensions/quickaccess/QuickAccessExtension.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/quickaccess/QuickAccessExtension.java
@@ -3,6 +3,7 @@ package ca.corbett.imageviewer.extensions.quickaccess;
 import ca.corbett.extensions.AppExtensionInfo;
 import ca.corbett.extras.properties.AbstractProperty;
 import ca.corbett.extras.properties.ComboProperty;
+import ca.corbett.extras.properties.IntegerProperty;
 import ca.corbett.imageviewer.AppConfig;
 import ca.corbett.imageviewer.QuickMoveManager;
 import ca.corbett.imageviewer.extensions.ImageViewerExtension;
@@ -35,6 +36,7 @@ public class QuickAccessExtension extends ImageViewerExtension implements UIRelo
 
     private static final String extInfoLocation = "/ca/corbett/imageviewer/extensions/quickaccess/extInfo.json";
     private static final String positionPropName = "Quick Move.Quick Access Extension.position";
+    public static final String panelWidthPropName = "Quick Move.Quick Access Extension.quickTagPanelWidth";
 
     private static final String WRONG_MODE_WARNING = "Not available\nin ImageSet mode.";
 
@@ -118,7 +120,8 @@ public class QuickAccessExtension extends ImageViewerExtension implements UIRelo
 
     @Override
     protected List<AbstractProperty> createConfigProperties() {
-        return List.of(
+        List<AbstractProperty> props = new ArrayList<>();
+        props.add(
             // We can't use EnumProperty because we don't support all enum options...
             // we only support Left and Right. So, use String-based combo instead.
             new ComboProperty<>(positionPropName,
@@ -127,6 +130,10 @@ public class QuickAccessExtension extends ImageViewerExtension implements UIRelo
                                 0,
                                 false)
         );
+
+        props.add(new IntegerProperty(panelWidthPropName, "Panel width:", 200, 120, 300, 10));
+
+        return props;
     }
 
     /**
@@ -229,6 +236,7 @@ public class QuickAccessExtension extends ImageViewerExtension implements UIRelo
     public void reloadUI() {
         for (QuickAccessPanel quickAccessPanel : quickAccessPanels) {
             quickAccessPanel.setActionPanelColors();
+            quickAccessPanel.refreshPreferredWidth(); // user may have changed the preferred quick panel width
             quickAccessPanel.applyLafWorkaround(); // user may have changed color scheme
         }
     }

--- a/src/main/java/ca/corbett/imageviewer/extensions/quickaccess/QuickAccessPanel.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/quickaccess/QuickAccessPanel.java
@@ -8,6 +8,7 @@ import ca.corbett.extras.actionpanel.ActionPanel;
 import ca.corbett.extras.actionpanel.ColorOptions;
 import ca.corbett.extras.actionpanel.ColorTheme;
 import ca.corbett.extras.image.animation.BlurLayerUI;
+import ca.corbett.extras.properties.AbstractProperty;
 import ca.corbett.extras.properties.IntegerProperty;
 import ca.corbett.imageviewer.AppConfig;
 import ca.corbett.imageviewer.ImageOperationHandler;
@@ -44,7 +45,7 @@ public final class QuickAccessPanel extends JPanel {
     private final JScrollPane scrollPane;
     private final QuickAccessExtension extension;
 
-    private int preferredPanelWidth = 200; // customized via AppConfig
+    private int panelMinWidth = 200; // customized via AppConfig
 
     /**
      * Creates a new, empty QuickAccessPanel.
@@ -89,11 +90,14 @@ public final class QuickAccessPanel extends JPanel {
      * from application settings and updates the instance variable.
      */
     public void refreshPreferredWidth() {
-        IntegerProperty prop = (IntegerProperty)AppConfig
-            .getInstance()
-            .getPropertiesManager()
-            .getProperty(QuickAccessExtension.panelWidthPropName);
-        preferredPanelWidth = prop == null ? 200 : prop.getValue();
+        AbstractProperty prop = AppConfig.getInstance().getPropertiesManager()
+                                         .getProperty(QuickAccessExtension.panelMinWidthPropName);
+        if (prop instanceof IntegerProperty intProp) {
+            panelMinWidth = intProp.getValue();
+        }
+        else {
+            panelMinWidth = 200; // fallback to default if something goes wrong
+        }
     }
 
     /**
@@ -281,7 +285,8 @@ public final class QuickAccessPanel extends JPanel {
             @Override
             public Dimension getPreferredSize() {
                 Dimension superPref = super.getPreferredSize();
-                return new Dimension(preferredPanelWidth, superPref.height);
+                // Return the larger of the two (panel's width may be larger if contents are large):
+                return new Dimension(Math.max(panelMinWidth, superPref.width), superPref.height);
             }
         };
 

--- a/src/main/java/ca/corbett/imageviewer/extensions/quickaccess/QuickAccessPanel.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/quickaccess/QuickAccessPanel.java
@@ -8,6 +8,7 @@ import ca.corbett.extras.actionpanel.ActionPanel;
 import ca.corbett.extras.actionpanel.ColorOptions;
 import ca.corbett.extras.actionpanel.ColorTheme;
 import ca.corbett.extras.image.animation.BlurLayerUI;
+import ca.corbett.extras.properties.IntegerProperty;
 import ca.corbett.imageviewer.AppConfig;
 import ca.corbett.imageviewer.ImageOperationHandler;
 import ca.corbett.imageviewer.QuickMoveManager;
@@ -22,6 +23,7 @@ import javax.swing.event.ChangeListener;
 import javax.swing.plaf.ColorUIResource;
 import java.awt.BorderLayout;
 import java.awt.Color;
+import java.awt.Dimension;
 import java.awt.event.ActionEvent;
 import java.io.File;
 
@@ -42,6 +44,8 @@ public final class QuickAccessPanel extends JPanel {
     private final JScrollPane scrollPane;
     private final QuickAccessExtension extension;
 
+    private int preferredPanelWidth = 200; // customized via AppConfig
+
     /**
      * Creates a new, empty QuickAccessPanel.
      */
@@ -52,6 +56,7 @@ public final class QuickAccessPanel extends JPanel {
         blurLayerUI = new BlurLayerUI();
         actionPanel = buildActionPanel();
         scrollPane = ScrollUtil.buildScrollPane(new JLayer<>(actionPanel, blurLayerUI));
+        refreshPreferredWidth();
         setActionPanelColors();
 
         // Set up a Look and Feel change listener so we can apply our workaround:
@@ -77,6 +82,18 @@ public final class QuickAccessPanel extends JPanel {
      */
     public boolean isBlurred() {
         return blurLayerUI.isBlurred();
+    }
+
+    /**
+     * Looks up the currently-configured preferred width for quick tag panels
+     * from application settings and updates the instance variable.
+     */
+    public void refreshPreferredWidth() {
+        IntegerProperty prop = (IntegerProperty)AppConfig
+            .getInstance()
+            .getPropertiesManager()
+            .getProperty(QuickAccessExtension.panelWidthPropName);
+        preferredPanelWidth = prop == null ? 200 : prop.getValue();
     }
 
     /**
@@ -255,8 +272,21 @@ public final class QuickAccessPanel extends JPanel {
      * Invoked internally to build an ActionPanel and configure it for our use.
      */
     private ActionPanel buildActionPanel() {
+        // This is very weird, but calling setPreferredSize() on the ActionPanel itself
+        // prevents the scrollbar from ever showing up, even when the parent container is too
+        // small to show all contents. The only way I've found to make this work is
+        // to override ActionPanel itself and return the preferred size from there.
+        // All of this, by the way, is just so we can set our preferred width. Sigh.
+        ActionPanel panel = new ActionPanel() {
+            @Override
+            public Dimension getPreferredSize() {
+                Dimension superPref = super.getPreferredSize();
+                return new Dimension(preferredPanelWidth, superPref.height);
+            }
+        };
+
+        // Now we can customize ActionPanel to get it to look the way we want it to.
         final int iconSize = 18;
-        ActionPanel panel = new ActionPanel();
         panel.setHeaderIconSize(iconSize);
         panel.getToolBarOptions().setIconSize(iconSize);
         panel.setActionComponentType(ActionComponentType.BUTTONS);


### PR DESCRIPTION
This PR addresses issue #15 by adding a configuration property that allows users to customize the quick access panel width, instead of relying on the panel to size itself based on its contents. This allows for a more consistent user experience, even when the selected labels are very short.

